### PR TITLE
Get rid of `static_data.types_to_values`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 
 # Python
 __pycache__/
-/venv/relay_demo/
+/venv/
 /.tox/
 
 /build/

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
-        "Development Status :: 1 - Planning",
+        "Development Status :: 2 - Pre-Alpha",
     ],
     # See sample layout:
     # https://docs.python.org/3/distutils/setupscript.html#installing-package-data
@@ -76,5 +76,4 @@ setuptools.setup(
     ],
     tests_require = tests_require,
     extras_require = extras_require,
-
 )

--- a/src/argrelay/meta_data/ServerConfig.py
+++ b/src/argrelay/meta_data/ServerConfig.py
@@ -27,6 +27,12 @@ class ServerConfig:
     They are are populated from `plugin_list` (key = `plugin_id`, value = `plugin_entry`).
     """
 
+    data_loaders: dict[str, "AbstractLoader"] = field(default_factory = lambda: {})
+    """
+    Entries in `data_loaders` are not directly loaded from config.
+    These are plugin instances created during plugin activation.
+    """
+
     interp_factories: dict[str, "AbstractInterpFactory"] = field(default_factory = lambda: {})
     """
     Entries in `interp_factories` are not directly loaded from config.

--- a/src/argrelay/meta_data/StaticData.py
+++ b/src/argrelay/meta_data/StaticData.py
@@ -10,5 +10,9 @@ class StaticData:
     """
 
     first_interp_factory_id: str = field(init = True, default = "")
-    types_to_values: dict[str, list[str]] = field(init = True, default_factory = lambda: {})
+
+    # TODO: It is currently populated, but not used.
+    #       It should probably be populated with config how to index these types in MongoDB:
+    known_types: list = field(init = True, default_factory = lambda: [])
+
     data_envelopes: list = field(init = True, default_factory = lambda: [])

--- a/src/argrelay/misc_helper/AbstractPlugin.py
+++ b/src/argrelay/misc_helper/AbstractPlugin.py
@@ -12,6 +12,19 @@ class AbstractPlugin:
         self.config_dict = config_dict
 
     def activate_plugin(self):
+        """
+        One-time plugin activation callback during server startup.
+
+        This is a chance to initialize (once) any resources plugin requires.
+        """
+        pass
+
+    def validate_loaded_data(self, static_data: "StaticData"):
+        """
+        Callback to validate data after all :class:`AbstractLoader`-s completed loading data.
+
+        This is a chance for any plugin to verify that the data still matches its expectation.
+        """
         pass
 
 

--- a/src/argrelay/mongo_data/MongoClientWrapper.py
+++ b/src/argrelay/mongo_data/MongoClientWrapper.py
@@ -22,6 +22,10 @@ def get_mongo_client(mongo_config: MongoConfig):
 
 
 def store_envelopes(mongo_db: Database, static_data: StaticData):
+    # TODO: Currently, we use single collection,
+    #       but we never search across all object,
+    #       we always search specific `envelope_class_`.
+    #       Should we use collection per envelope class?
     col_proxy: Collection = mongo_db[data_envelopes_]
     col_proxy.delete_many({})
 

--- a/src/argrelay/plugin_interp/GenericInterp.py
+++ b/src/argrelay/plugin_interp/GenericInterp.py
@@ -69,6 +69,7 @@ class GenericInterp(AbstractInterp):
         self.function_query = config_dict[function_query_]
         # TODO: provide dict in config directly, there is no usage of list variant (no ordering is defined by this list):
         self.envelope_class_queries_list = config_dict[envelope_class_queries_]
+        # Convert list to dict:
         self.envelope_class_queries_dict = {}
         for envelope_class_query in self.envelope_class_queries_list:
             self.envelope_class_queries_dict[envelope_class_query[envelope_class_]] = envelope_class_query
@@ -286,7 +287,7 @@ class GenericInterp(AbstractInterp):
             # TODO: instead of looping through all `types_to_values` possible in `static_data`,
             #       loop through those types used in query for that object:
             # `arg_type` must be known:
-            for arg_type in self.interp_ctx.static_data.types_to_values.keys():
+            for arg_type in self.curr_types_to_keys.keys():
                 # `arg_type` must be in one of the `data_envelope`-s found:
                 if arg_type in envelope_found:
                     # `arg_type` must not be assigned/consumed:
@@ -321,7 +322,8 @@ class GenericInterp(AbstractInterp):
             if self.interp_ctx.parsed_ctx.sel_token_l_part == "":
                 return self.remaining_from_next_missing_types()
             else:
-                return self.remaining_from_all_missing_types()
+                # TODO: Suggest keys (:) of missing types instead - it is `SubsequentHelp`, user insist and wants something else:
+                return self.remaining_from_next_missing_types()
 
         if self.interp_ctx.parsed_ctx.sel_token_l_part == "":
             # assert t == CompType.PartialWord, "Is this partial word but selected token left part is empty?"
@@ -374,20 +376,6 @@ class GenericInterp(AbstractInterp):
                         x.startswith(self.interp_ctx.parsed_ctx.sel_token_l_part)
                         # TODO: Support list[str] - what if one type can have list of values (and we need to match any as in OR)?
                     )
-                ]
-
-        return proposed_tokens
-
-    def remaining_from_all_missing_types(self) -> list[str]:
-        proposed_tokens: list[str] = []
-
-        # Add entire value sets for missing args to proposed set:
-        for arg_type in self.curr_types_to_keys.keys():
-            if arg_type not in self.interp_ctx.curr_assigned_types_to_values:
-                proposed_tokens += [
-                    # TODO: if these values are populated by all possible automatically, do we still want to propose from all regardless current object class context? On `SubsequentHelp`? I don't think so.
-                    x for x in self.interp_ctx.static_data.types_to_values[arg_type]
-                    if x.startswith(self.interp_ctx.parsed_ctx.sel_token_l_part)
                 ]
 
         return proposed_tokens

--- a/src/argrelay/plugin_interp/GenericInterpFactory.py
+++ b/src/argrelay/plugin_interp/GenericInterpFactory.py
@@ -1,7 +1,8 @@
 from argrelay.plugin_interp.AbstractInterpFactory import AbstractInterpFactory
 from argrelay.plugin_interp.GenericInterp import GenericInterp
 from argrelay.runtime_context.InterpContext import InterpContext
-from argrelay.schema_config_interp.GenericInterpConfigSchema import generic_interp_config_desc
+from argrelay.schema_config_interp.EnvelopeClassQuerySchema import keys_to_types_list_
+from argrelay.schema_config_interp.GenericInterpConfigSchema import generic_interp_config_desc, function_query_
 
 
 class GenericInterpFactory(AbstractInterpFactory):
@@ -12,3 +13,37 @@ class GenericInterpFactory(AbstractInterpFactory):
 
     def create_interp(self, interp_ctx: InterpContext) -> GenericInterp:
         raise NotImplementedError
+
+    def validate_loaded_data(self, static_data: "StaticData"):
+        self._validate_function_envelopes_have_unique_coordinates(static_data)
+
+    def _validate_function_envelopes_have_unique_coordinates(self, static_data: "StaticData"):
+        """
+        Verify that all arg types listed to query functions uniquely identify all function with such arg types
+
+        Otherwise, functions which do not have unque coordinates with listed arg types will not be invokable.
+
+        * Find all envelopes of `ReservedEnvelopeClass.ClassFunction`.
+        * Take those of them which have all arg types listed in plugin config.
+        * Make sure all arg values (ordered by arg type) have unique tuple.
+        """
+
+        types_list = GenericInterp.list_to_dict(self.config_dict[function_query_][keys_to_types_list_]).values()
+
+        all_typed_values_lists = []
+        for data_envelope in static_data.data_envelopes:
+
+            all_types_exist = True
+            typed_values_list = []
+            for type_name in types_list:
+                if type_name not in data_envelope:
+                    all_types_exist = False
+                    break
+                else:
+                    typed_values_list.append(data_envelope[type_name])
+
+            if all_types_exist:
+                assert typed_values_list not in all_typed_values_lists
+                all_typed_values_lists.append(typed_values_list)
+            else:
+                continue

--- a/src/argrelay/relay_demo/GitRepoLoader.py
+++ b/src/argrelay/relay_demo/GitRepoLoader.py
@@ -78,8 +78,8 @@ class GitRepoLoader(AbstractLoader):
 
         # Init type keys (if they do not exist):
         for type_name in [enum_item.name for enum_item in GitRepoArgType]:
-            if type_name not in static_data.types_to_values.keys():
-                static_data.types_to_values[type_name] = []
+            if type_name not in static_data.known_types:
+                static_data.known_types.append(type_name)
 
         data_envelopes = static_data.data_envelopes
 
@@ -90,8 +90,6 @@ class GitRepoLoader(AbstractLoader):
         for abs_git_path in git_repo_paths.keys():
             rel_git_path = git_repo_paths[abs_git_path]
             print(f"Git repo to load: {rel_git_path}")
-            # TODO: `types_to_values` should be updated automatically after loading all envelopes:
-            static_data.types_to_values[GitRepoArgType.GitRepoRelPath.name].append(rel_git_path)
 
             # Produce relative path, for example, if:
             # base_path_ = "/path/to/base/dir/"
@@ -100,8 +98,8 @@ class GitRepoLoader(AbstractLoader):
             # rel_git_path = "rel/path/to/git/repo.git/"
             # path_comp_list = [ "rel", "path", "to", "git", "repo" ]
             rel_git_path = git_repo_paths[abs_git_path]
-            # TODO: `types_to_values` should be updated automatically after loading all envelopes:
-            path_comp_list = static_data.types_to_values[GitRepoArgType.GitRepoPathComp.name]
+
+            path_comp_list = []
             for rel_git_path_comp in rel_git_path.split(os.sep)[:-1]:
                 if rel_git_path_comp not in path_comp_list:
                     path_comp_list.append(rel_git_path_comp)
@@ -129,14 +127,6 @@ class GitRepoLoader(AbstractLoader):
 
             git_repo = Repo(abs_git_path)
             for git_commit in git_repo.iter_commits():
-                # TODO: `types_to_values` should be updated automatically after loading all envelopes:
-                static_data.types_to_values[
-                    GitRepoArgType.GitRepoCommitId.name
-                ].append(git_commit.hexsha)
-                static_data.types_to_values[
-                    GitRepoArgType.GitRepoCommitAuthorEmail.name
-                ].append(git_commit.author.email)
-
                 ########################################################################################################
                 # commits
 

--- a/src/argrelay/relay_demo/GitRepoLoader.py
+++ b/src/argrelay/relay_demo/GitRepoLoader.py
@@ -171,7 +171,7 @@ class GitRepoLoader(AbstractLoader):
             GlobalArgType.ActionType.name: "desc",
             GlobalArgType.ObjectSelector.name: "repo",
         }
-        self._merge_function_envelopes(data_envelopes, given_function_envelope)
+        data_envelopes.append(given_function_envelope)
 
         given_function_envelope = {
             envelope_id_: "desc_commit",
@@ -185,41 +185,6 @@ class GitRepoLoader(AbstractLoader):
             GlobalArgType.ActionType.name: "desc",
             GlobalArgType.ObjectSelector.name: "commit",
         }
-        self._merge_function_envelopes(data_envelopes, given_function_envelope)
+        data_envelopes.append(given_function_envelope)
 
         return static_data
-
-    # noinspection PyMethodMayBeStatic
-    def _merge_function_envelopes(self, data_envelopes: list, given_func_envelope):
-
-        is_found = False
-        for data_envelope in data_envelopes:
-            if (
-                (envelope_id_ in data_envelope)
-                and
-                (data_envelope[envelope_id_] == given_func_envelope[envelope_id_])
-                and
-                (envelope_class_ in data_envelope)
-                and
-                (data_envelope[envelope_class_] == given_func_envelope[envelope_class_])
-            ):
-                # Update existing function envelope:
-                if not is_found:
-                    is_found = True
-
-                    # Can we really support any other `envelope class`-es for this function?
-                    assert len(data_envelope[envelope_payload_][accept_envelope_classes_]) == 0
-                    data_envelope[envelope_payload_][accept_envelope_classes_].extend(
-                        given_func_envelope[envelope_payload_][accept_envelope_classes_]
-                    )
-
-                    assert data_envelope[GlobalArgType.ActionType.name] == given_func_envelope[
-                        GlobalArgType.ActionType.name]
-                    data_envelope[GlobalArgType.ObjectSelector.name] = given_func_envelope[
-                        GlobalArgType.ObjectSelector.name]
-
-                else:
-                    raise RuntimeError
-        if not is_found:
-            # Insert given function envelope:
-            data_envelopes.append(given_func_envelope)

--- a/src/argrelay/relay_demo/ServiceLoader.py
+++ b/src/argrelay/relay_demo/ServiceLoader.py
@@ -7,7 +7,6 @@ from argrelay.plugin_invocator.ErrorInvocator import ErrorInvocator
 from argrelay.plugin_loader.AbstractLoader import AbstractLoader
 from argrelay.relay_demo.ServiceArgType import ServiceArgType
 from argrelay.relay_demo.ServiceEnvelopeClass import ServiceEnvelopeClass
-from argrelay.schema_config_core_server.StaticDataSchema import types_to_values_
 from argrelay.schema_config_interp.DataEnvelopeSchema import (
     envelope_payload_,
     envelope_id_,
@@ -41,30 +40,20 @@ class ServiceLoader(AbstractLoader):
 
     def update_static_data(self, static_data: StaticData) -> StaticData:
 
-        static_data = self.load_types_to_values(static_data)
         static_data = self.load_data_envelopes(static_data)
-
-        return static_data
-
-    def load_types_to_values(self, static_data: StaticData) -> StaticData:
-        """
-        The loader simply merges content its `config_dict` into `static_data`.
-        """
-
-        config_types_to_values: dict[str, list[str]] = self.config_dict[types_to_values_]
-        for type_name, values_list in config_types_to_values.items():
-            if type_name in static_data.types_to_values:
-                static_data.types_to_values[type_name].extend(values_list)
-            else:
-                static_data.types_to_values[type_name] = values_list
 
         return static_data
 
     # noinspection PyMethodMayBeStatic
     def load_data_envelopes(self, static_data: StaticData) -> StaticData:
         """
-        The loader hard-codes samples into `static_data["data_envelopes"]`
+        The loader writes samples into `static_data["data_envelopes"]` simply from code (without any data source).
         """
+
+        # Init type keys (if they do not exist):
+        for type_name in [enum_item.name for enum_item in ServiceArgType]:
+            if type_name not in static_data.known_types:
+                static_data.known_types.append(type_name)
 
         # TODO: This loader overwrites existing object list (it has to patch it instead).
         #       This is fine for now because `ServiceLoader` is used first in config.

--- a/src/argrelay/relay_demo/argrelay.server.yaml
+++ b/src/argrelay/relay_demo/argrelay.server.yaml
@@ -93,7 +93,7 @@ plugin_list:
         plugin_class_name: GitRepoLoader
         plugin_type: LoaderPlugin
         plugin_config:
-            is_enabled: False
+            is_enabled: True
             base_path: "~/repos"
 
     -   plugin_id: GitRepoInvocator

--- a/src/argrelay/relay_demo/argrelay.server.yaml
+++ b/src/argrelay/relay_demo/argrelay.server.yaml
@@ -80,20 +80,14 @@ plugin_list:
         plugin_module_name: argrelay.relay_demo.ServiceLoader
         plugin_class_name: ServiceLoader
         plugin_type: LoaderPlugin
-        plugin_config:
-
-            types_to_values:
-
-                ColorTag:
-                    - red
-                    - green
+        plugin_config: { }
 
     -   plugin_id: GitRepoLoader
         plugin_module_name: argrelay.relay_demo.GitRepoLoader
         plugin_class_name: GitRepoLoader
         plugin_type: LoaderPlugin
         plugin_config:
-            is_enabled: True
+            is_enabled: False
             base_path: "~/repos"
 
     -   plugin_id: GitRepoInvocator
@@ -121,60 +115,6 @@ static_data:
 
     first_interp_factory_id: FirstArgInterpFactory
 
-    types_to_values:
-
-        # TODO: only define list of types, populating `types_to_values` should be automatic from all loaded envelopes:
-        ActionType:
-            - goto
-            - desc
-            - list
-
-        ObjectSelector:
-            - host
-            - service
-            - repo
-            - commit
-
-        CodeMaturity:
-            - dev
-            - qa
-            - prod
-
-        FlowStage:
-            - upstream
-            - downstream
-
-        GeoRegion:
-            - amer
-            - emea
-            - apac
-
-        # Host names are just some strings with prefixes for testing:
-        HostName:
-            - qw
-            - qwe
-            - qwer
-            - wert
-
-            - as
-            - asd
-            - asdf
-            - sdfg
-
-            - zx
-            - zxc
-            - zxcv
-            - xcvb
-
-        ServiceName:
-            - service_a
-            - service_b
-            - service_c
-
-        AccessType:
-            - ro
-            - rw
-
-        ColorTag: [ ]
+    known_types: [ ]
 
     data_envelopes: [ ]

--- a/src/argrelay/runtime_context/InterpContext.py
+++ b/src/argrelay/runtime_context/InterpContext.py
@@ -201,9 +201,6 @@ class InterpContext:
 
                 eprint()
 
-    def is_type_with_values(self, arg_type: str) -> bool:
-        return len(self.static_data.types_to_values[arg_type]) != 0
-
     def print_debug(self) -> None:
         if not self.parsed_ctx.is_debug_enabled:
             return

--- a/src/argrelay/schema_config_core_server/StaticDataSchema.py
+++ b/src/argrelay/schema_config_core_server/StaticDataSchema.py
@@ -7,7 +7,7 @@ from argrelay.misc_helper.TypeDesc import TypeDesc
 from argrelay.schema_config_interp.DataEnvelopeSchema import data_envelope_desc
 
 first_interp_factory_id_ = "first_interp_factory_id"
-types_to_values_ = "types_to_values"
+known_types_ = "known_types"
 data_envelopes_ = "data_envelopes"
 
 
@@ -19,10 +19,8 @@ class StaticDataSchema(Schema):
     first_interp_factory_id = fields.String(
         required = True,
     )
-    types_to_values = fields.Dict(
-        keys = fields.String(),
-        values = fields.List(fields.String()),
-        default = {},
+    known_types = fields.List(
+        fields.String(),
         required = True,
     )
     data_envelopes = fields.List(
@@ -34,7 +32,7 @@ class StaticDataSchema(Schema):
     def make_object(self, input_dict, **kwargs):
         return StaticData(
             first_interp_factory_id = input_dict[first_interp_factory_id_],
-            types_to_values = input_dict[types_to_values_],
+            known_types = input_dict[known_types_],
             data_envelopes = input_dict[data_envelopes_],
         )
 
@@ -44,16 +42,10 @@ static_data_desc = TypeDesc(
     ref_name = StaticDataSchema.__name__,
     dict_example = {
         first_interp_factory_id_: "SomeInterp",
-        types_to_values_: {
-            "SomeTypeA": [
-                "A_value_1",
-                "A_value_2",
-            ],
-            "SomeTypeB": [
-                "B_value_1",
-                "B_value_2",
-            ],
-        },
+        known_types_: [
+            "SomeTypeA",
+            "SomeTypeB",
+        ],
         data_envelopes_: [
             data_envelope_desc.dict_example,
         ]

--- a/src/argrelay/schema_config_core_server/StaticDataSchema.py
+++ b/src/argrelay/schema_config_core_server/StaticDataSchema.py
@@ -35,6 +35,7 @@ class StaticDataSchema(Schema):
         return StaticData(
             first_interp_factory_id = input_dict[first_interp_factory_id_],
             types_to_values = input_dict[types_to_values_],
+            data_envelopes = input_dict[data_envelopes_],
         )
 
 

--- a/tests/env_tests/test_MongoClient_envelope_search.py
+++ b/tests/env_tests/test_MongoClient_envelope_search.py
@@ -4,7 +4,6 @@ from pymongo.database import Database
 from argrelay.mongo_data.MongoClientWrapper import get_mongo_client
 from argrelay.relay_demo.ServiceArgType import ServiceArgType
 from argrelay.schema_config_core_server.MongoConfigSchema import mongo_config_desc
-from argrelay.schema_config_core_server.StaticDataSchema import types_to_values_
 from env_tests.MongoClientTest import MongoClientTest
 
 
@@ -20,7 +19,7 @@ class ThisTestCase(MongoClientTest):
         mongo_client = get_mongo_client(mongo_config)
         print("list_database_names: ", mongo_client.list_database_names())
 
-        mongo_db: Database = mongo_client[mongo_config.database_name]
+        mongo_db: Database = mongo_client[mongo_config.mongo_server.database_name]
         print("list_collection_names: ", mongo_db.list_collection_names())
 
         col_name = "argrelay"
@@ -28,44 +27,42 @@ class ThisTestCase(MongoClientTest):
 
         self.remove_all_envelopes(col_proxy)
 
+        index_fields = [
+            ServiceArgType.AccessType.name,
+            ServiceArgType.ColorTag.name,
+            ServiceArgType.CodeMaturity.name,
+        ]
+
         envelope_001 = {
             "envelope_payload": {
                 "object_name": "envelope_001",
             },
-            types_to_values_: {
-                ServiceArgType.AccessType.name: "ro",
-            },
+            ServiceArgType.AccessType.name: "ro",
         }
 
         envelope_002 = {
             "envelope_payload": {
                 "object_name": "envelope_002",
             },
-            types_to_values_: {
-                ServiceArgType.AccessType.name: "rw",
-                ServiceArgType.ColorTag.name: "red",
-            },
+            ServiceArgType.AccessType.name: "rw",
+            ServiceArgType.ColorTag.name: "red",
         }
 
         envelope_003 = {
             "envelope_payload": {
                 "object_name": "envelope_003",
             },
-            types_to_values_: {
-                ServiceArgType.AccessType.name: "rw",
-                ServiceArgType.ColorTag.name: "blue",
-            },
+            ServiceArgType.AccessType.name: "rw",
+            ServiceArgType.ColorTag.name: "blue",
         }
 
         envelope_004 = {
             "envelope_payload": {
                 "object_name": "envelope_004",
             },
-            types_to_values_: {
-                ServiceArgType.AccessType.name: "rw",
-                ServiceArgType.ColorTag.name: "red",
-                ServiceArgType.CodeMaturity.name: "prod",
-            },
+            ServiceArgType.AccessType.name: "rw",
+            ServiceArgType.ColorTag.name: "red",
+            ServiceArgType.CodeMaturity.name: "prod",
         }
 
         col_proxy.insert_many([
@@ -75,13 +72,14 @@ class ThisTestCase(MongoClientTest):
             envelope_004,
         ])
 
-        col_proxy.create_index(types_to_values_)
+        for index_field in index_fields:
+            col_proxy.create_index(index_field)
 
         print("query 1:")
         for data_envelope in col_proxy.find(
             {
-                f"types_to_values.{ServiceArgType.AccessType.name}": "rw",
-                f"types_to_values.{ServiceArgType.ColorTag.name}": "red",
+                ServiceArgType.AccessType.name: "rw",
+                ServiceArgType.ColorTag.name: "red",
             }
         ):
             print("data_envelope: ", data_envelope)

--- a/tests/offline_tests/interp_plugin/test_GenericInterpFactory.py
+++ b/tests/offline_tests/interp_plugin/test_GenericInterpFactory.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from argrelay.meta_data.CompType import CompType
+from argrelay.meta_data.PluginType import PluginType
+from argrelay.meta_data.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.meta_data.RunMode import RunMode
+from argrelay.plugin_interp.GenericInterpFactory import GenericInterpFactory
+from argrelay.plugin_invocator.NoopInvocator import NoopInvocator
+from argrelay.relay_client import __main__
+from argrelay.schema_config_core_server.ServerConfigSchema import plugin_list_, static_data_
+from argrelay.schema_config_core_server.StaticDataSchema import data_envelopes_
+from argrelay.schema_config_interp.DataEnvelopeSchema import envelope_id_, envelope_payload_
+from argrelay.schema_config_interp.EnvelopeClassQuerySchema import envelope_class_, keys_to_types_list_
+from argrelay.schema_config_interp.FunctionEnvelopePayloadSchema import invocator_plugin_id_
+from argrelay.schema_config_interp.GenericInterpConfigSchema import function_query_, envelope_class_queries_
+from argrelay.schema_config_plugin.PluginEntrySchema import (
+    plugin_id_,
+    plugin_config_, plugin_module_name_, plugin_class_name_, plugin_type_,
+)
+from argrelay.test_helper import parse_line_and_cpos
+from argrelay.test_helper.EnvMockBuilder import (
+    EnvMockBuilder,
+    load_relay_demo_server_config_dict,
+    load_relay_demo_client_config_dict,
+)
+
+
+class ThisTestCase(TestCase):
+
+    def test_validate_function_envelopes_have_unique_coordinates(self):
+        client_config_dict = load_relay_demo_client_config_dict()
+        server_config_dict = load_relay_demo_server_config_dict()
+        data_envelopes = server_config_dict[static_data_][data_envelopes_]
+
+        (command_line, cursor_cpos) = parse_line_and_cpos("some_command |")
+
+        type_1 = "whatever_type_1"
+        type_2 = "whatever_type_2"
+
+        # Configure new `GenericInterpFactory`:
+        server_config_dict[plugin_list_].append({
+            plugin_id_: GenericInterpFactory.__name__ + ".test",
+            plugin_module_name_: GenericInterpFactory.__module__,
+            plugin_class_name_: GenericInterpFactory.__name__,
+            plugin_type_: PluginType.InterpFactoryPlugin.name,
+            plugin_config_: {
+                function_query_: {
+                    envelope_class_: ReservedEnvelopeClass.ClassFunction.name,
+                    keys_to_types_list_: [
+                        {type_1: type_1},
+                        {type_2: type_2},
+                    ]
+                },
+                envelope_class_queries_: {
+                }
+            }
+        })
+
+        # Add two functions with unique coordinates:
+        given_function_envelope = {
+            envelope_id_: "func_1",
+            envelope_class_: ReservedEnvelopeClass.ClassFunction.name,
+            envelope_payload_: {
+                invocator_plugin_id_: NoopInvocator.__name__,
+            },
+            type_1: "type_1_value_1",
+            type_2: "type_2_value_1",
+        }
+        data_envelopes.append(given_function_envelope)
+        given_function_envelope = {
+            envelope_id_: "func_2",
+            envelope_class_: ReservedEnvelopeClass.ClassFunction.name,
+            envelope_payload_: {
+                invocator_plugin_id_: NoopInvocator.__name__,
+            },
+            type_1: "type_1_value_2",
+            type_2: "type_2_value_2",
+        }
+        data_envelopes.append(given_function_envelope)
+
+        # Test 1: should pass
+        env_mock_builder = (
+            EnvMockBuilder()
+            .set_run_mode(RunMode.CompletionMode)
+            .set_command_line(command_line)
+            .set_cursor_cpos(cursor_cpos)
+            .set_comp_type(CompType.PrefixShown)
+            .set_server_config_dict(server_config_dict)
+        )
+        with env_mock_builder.build():
+            __main__.main()
+            self.assertTrue(True)
+
+        # Add function with non-unique coordinates:
+        given_function_envelope = {
+            envelope_id_: "func_3",
+            envelope_class_: ReservedEnvelopeClass.ClassFunction.name,
+            envelope_payload_: {
+                invocator_plugin_id_: NoopInvocator.__name__,
+            },
+            type_1: "type_1_value_1",
+            type_2: "type_2_value_1",
+        }
+        data_envelopes.append(given_function_envelope)
+
+        # Test 2: should fail
+        with self.assertRaises(AssertionError):
+            env_mock_builder = (
+                EnvMockBuilder()
+                .set_run_mode(RunMode.CompletionMode)
+                .set_command_line(command_line)
+                .set_cursor_cpos(cursor_cpos)
+                .set_comp_type(CompType.PrefixShown)
+                .set_server_config_dict(server_config_dict)
+            )
+            with env_mock_builder.build():
+                __main__.main()
+                self.assertTrue("unreachable")

--- a/tests/offline_tests/schema_config_core_server/test_StaticDataSchema.py
+++ b/tests/offline_tests/schema_config_core_server/test_StaticDataSchema.py
@@ -4,8 +4,11 @@ from jsonschema.exceptions import ValidationError
 from marshmallow import ValidationError
 
 from argrelay.schema_config_core_server.ServerConfigSchema import static_data_
-from argrelay.schema_config_core_server.StaticDataSchema import static_data_desc, types_to_values_, \
-    first_interp_factory_id_
+from argrelay.schema_config_core_server.StaticDataSchema import (
+    static_data_desc,
+    first_interp_factory_id_,
+    known_types_, data_envelopes_,
+)
 from argrelay.test_helper import line_no
 from argrelay.test_helper.EnvMockBuilder import load_relay_demo_server_config_dict
 
@@ -22,34 +25,20 @@ class ThisTestCase(TestCase):
                 line_no(), "basic sample",
                 {
                     first_interp_factory_id_: "FirstArgInterpFactory",
-                    types_to_values_: {
-                        "action": [
-                            "goto",
-                            "desc",
-                            "list",
-                        ],
-                        "access": [
-                            "ro",
-                            "rw",
-                        ],
-                    },
-                    "data_envelopes": [
+                    known_types_: [
+                        "action",
+                        "access",
+                    ],
+                    data_envelopes_: [
                     ],
                 },
                 {
                     first_interp_factory_id_: "FirstArgInterpFactory",
-                    types_to_values_: {
-                        "action": [
-                            "goto",
-                            "desc",
-                            "list",
-                        ],
-                        "access": [
-                            "ro",
-                            "rw",
-                        ],
-                    },
-                    "data_envelopes": [
+                    known_types_: [
+                        "action",
+                        "access",
+                    ],
+                    data_envelopes_: [
                     ],
                 },
                 None,
@@ -66,8 +55,8 @@ class ThisTestCase(TestCase):
                 line_no(), "without required field (`data_envelopes`)",
                 {
                     first_interp_factory_id_: "FirstArgInterpFactory",
-                    types_to_values_: {
-                    },
+                    known_types_: [
+                    ],
                 },
                 {
                     first_interp_factory_id_: "FirstArgInterpFactory",
@@ -78,17 +67,17 @@ class ThisTestCase(TestCase):
                 line_no(), "with extra key (`whatever_extra_key`) which is not allowed",
                 {
                     first_interp_factory_id_: "FirstArgInterpFactory",
-                    "types_to_values": {
-                    },
-                    "data_envelopes": [
+                    known_types_: [
+                    ],
+                    data_envelopes_: [
                     ],
                     "whatever_extra_key": "whatever_extra_val",
                 },
                 {
                     first_interp_factory_id_: "FirstArgInterpFactory",
-                    types_to_values_: {
-                    },
-                    "data_envelopes": [
+                    known_types_: [
+                    ],
+                    data_envelopes_: [
                     ],
                 },
                 ValidationError,

--- a/tests/online_tests/relay_demo/test_GitRepoLoader.py
+++ b/tests/online_tests/relay_demo/test_GitRepoLoader.py
@@ -36,7 +36,7 @@ class ThisTestCase(TestCase):
                 },
                 {
                     "git_root_path": "qwer/xyz",
-                    "git_remote_url": "git@github.com:uvsmtid/argrelay.git",
+                    "git_remote_url": "git@github.com:kislyuk/argcomplete.git",
                 },
                 {
                     "git_root_path": "zxcv",

--- a/tests/online_tests/relay_demo/test_GitRepoLoader.py
+++ b/tests/online_tests/relay_demo/test_GitRepoLoader.py
@@ -8,8 +8,6 @@ from argrelay.misc_helper import eprint
 from argrelay.relay_demo.GitRepoArgType import GitRepoArgType
 from argrelay.relay_demo.GitRepoLoader import GitRepoLoader
 from argrelay.relay_demo.GitRepoLoaderConfigSchema import base_path_, is_enabled_
-from argrelay.schema_config_core_server.ServerConfigSchema import static_data_
-from argrelay.schema_config_core_server.StaticDataSchema import types_to_values_
 from argrelay.test_helper import line_no
 from argrelay.test_helper.EnvMockBuilder import relay_demo_static_data_object
 
@@ -88,8 +86,12 @@ class ThisTestCase(TestCase):
                 git_repo_loader = GitRepoLoader(plugin_config)
                 static_data = git_repo_loader.update_static_data(static_data)
 
-                # TODO: When `types_to_values` become auto-populated, showing them here does not make sense:
-                print(f"curr `{static_data_}.{types_to_values_}`:")
                 for type_name in [enum_item.name for enum_item in GitRepoArgType]:
-                    assert type_name in static_data.types_to_values
-                    print(f"{type_name}: ", static_data.types_to_values[type_name])
+                    assert type_name in static_data.known_types
+
+                    # Find list all values in data_envelope per `type_name`:
+                    typed_values = []
+                    for data_envelope in static_data.data_envelopes:
+                        if type_name in data_envelope:
+                            typed_values.append(data_envelope[type_name])
+                    print(f"type_to_values: {type_name}: {typed_values}")

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -23,6 +23,9 @@ The only useful practical difference between them are these directories:
 
     They are in separate directory (excluded from running automatically) instead of `@skip`-ping them.
 
+    This dir is the only one where `__init__.py` is absent -
+    tests there are not discoverable if started from root `tests` dir.
+
 *   `release_tests`
 
     Separate category of tests which are okay to fail on branches (and it is okay not to run them to avoid noise),

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -22,3 +22,8 @@ The only useful practical difference between them are these directories:
     (rely on some running service, need some files, etc.).
 
     They are in separate directory (excluded from running automatically) instead of `@skip`-ping them.
+
+*   `release_tests`
+
+    Separate category of tests which are okay to fail on branches (and it is okay not to run them to avoid noise),
+    but they will eventually need to pass before release.

--- a/tests/release_tests/__init__.py
+++ b/tests/release_tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+"""
+# Intentionally empty: enables test discovery within this dir.

--- a/tests/release_tests/test_pre_publish.py
+++ b/tests/release_tests/test_pre_publish.py
@@ -3,6 +3,7 @@ Check things which should not be published
 
 For example, `GitRepoLoader` should not be enabled in `argrelay.server.yaml`.
 """
+import os
 from unittest import TestCase
 
 from argrelay.meta_data.ServerConfig import ServerConfig
@@ -38,3 +39,19 @@ class ThisTestCase(TestCase):
             raise RuntimeError("missing " + GitRepoLoader_class.__name__ + " plugin?")
 
         self.assertFalse(git_loader_plugin.plugin_config[is_enabled_])
+
+    def test_env_tests_have_no_init_file(self):
+        """
+        There should be no `__init__.py` file under `env_tests` directory.
+
+        This keeps all tests under `env_tests` non-discoverable when run from `env_tests`.
+
+        See `tests/readme.md`.
+        """
+
+        # When IDE runs, CWD="tests", when `tox` runs, CWD=[repo root], so change to `tests` subdir:
+        if os.path.basename(os.getcwd()) != "tests":
+            os.chdir("tests")
+
+        self.assertTrue(os.path.isdir("env_tests"))
+        self.assertFalse(os.path.exists("env_tests/__init__.py"))

--- a/tests/release_tests/test_pre_publish.py
+++ b/tests/release_tests/test_pre_publish.py
@@ -1,0 +1,40 @@
+"""
+Check things which should not be published
+
+For example, `GitRepoLoader` should not be enabled in `argrelay.server.yaml`.
+"""
+from unittest import TestCase
+
+from argrelay.meta_data.ServerConfig import ServerConfig
+from argrelay.relay_demo import GitRepoLoader as GitRepoLoader_module
+from argrelay.relay_demo.GitRepoLoader import GitRepoLoader as GitRepoLoader_class
+from argrelay.relay_demo.GitRepoLoaderConfigSchema import is_enabled_
+from argrelay.schema_config_core_server.ServerConfigSchema import (
+    server_config_desc,
+)
+
+
+class ThisTestCase(TestCase):
+
+    def test_git_repo_loader_is_disabled(self):
+        """
+        `GitRepoLoader` should not be enabled in `argrelay.server.yaml`.
+        """
+
+        server_config: ServerConfig = server_config_desc.from_default_file()
+        found_one = False
+        git_loader_plugin = None
+        for plugin_item in server_config.plugin_list:
+            if (
+                plugin_item.plugin_module_name == GitRepoLoader_module.__name__
+                and
+                plugin_item.plugin_class_name == GitRepoLoader_class.__name__
+            ):
+                if found_one:
+                    raise RuntimeError("two " + GitRepoLoader_class.__name__ + " plugins?")
+                found_one = True
+                git_loader_plugin = plugin_item
+        if not found_one:
+            raise RuntimeError("missing " + GitRepoLoader_class.__name__ + " plugin?")
+
+        self.assertFalse(git_loader_plugin.plugin_config[is_enabled_])

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,5 @@ extras = test
 commands =
     # run all offline tests only:
     python -m unittest discover --verbose --start-directory tests/offline_tests
+    # special pre-release tests:
+    python -m unittest discover --verbose --start-directory tests/release_tests


### PR DESCRIPTION
*   Main `types_to_values` are not static and depend on current query.
    Removed from `static_data`.
*   Extras:
    *   Add validation that all function envelopes used by `GenericInterp` have unique coordinates.
    *   Add `release_tests` for things to fail only on `tox` build.