### PR TITLE
Show `help_hint` for completion args

### DIFF
--- a/docs/feature_stories/FS_71_87_33_52.help_hint.md
+++ b/docs/feature_stories/FS_71_87_33_52.help_hint.md
@@ -8,8 +8,36 @@ Help hint is a single line explanation which can be shown:
 *   next to suggested arg type during completion
 *   in listing of `data_envelope`-s found as varargs (FS_06_99_43_60)
 
+The trick is to keep providing extended string when there are multiple arg value options,<br/>
+then, when only single options is available,<br/>
+`help_hint` (everything after first space: KI_99_81_19_25 ) is removed.
+
 While `help_doc` (FS_94_30_49_28) can be shown on request,
 `help_hint` shows up automatically during completion.
 
 Implementation will likely involve a separate query
 for `help_hints` per arg type.
+
+Currently, as a demo for `help_hint` during completion,
+all help hints are stored once on startup (and do not change until server restarts)
+into a dict with this structure:
+
+```python
+{
+    f"{arg_type}": {
+        f"{arg_value}": f"{help_hint}",
+    },
+}
+```
+
+At the startup, `data_envelope`-s of this class and values will populate dict above:
+
+```python
+{
+    f"{ReservedArgType.EnvelopeClass.name}": f"{ReservedEnvelopeClass.ClassHelp.name}",
+    f"{ReservedArgType.ArgType.name}": f"{arg_type}",
+    f"{ReservedArgType.ArgValue.name}": f"{arg_value}",
+    f"{ReservedArgType.HelpHint.name}": f"{help_text}",
+}
+```
+

--- a/docs/feature_stories/FS_94_30_49_28.help_doc.md
+++ b/docs/feature_stories/FS_94_30_49_28.help_doc.md
@@ -10,3 +10,4 @@ Unlike `help_hint` (FS_71_87_33_52), it does not affect command line interface l
 
 Implementation is likely straightforward:
 store `help_doc` together with the `data_envelope`.
+Alternative way is to search `help_doc` (possibly in a separate collection) based on given `data_envelope` properties.

--- a/docs/known_issues/KI_99_81_19_25.no_space_in_options.md
+++ b/docs/known_issues/KI_99_81_19_25.no_space_in_options.md
@@ -1,0 +1,9 @@
+---
+known_issue: KI_99_81_19_25
+issue_title: no space in options
+---
+
+At the moment, `argrelay` does not support (white) space chars in arg value options.
+
+In fact, current impl of FS_71_87_33_52 `help_hint` feature relies on that by removing
+`help_hint` (trailing part of string after first space) in case of single option.

--- a/src/argrelay/custom_integ/ServiceLoader.py
+++ b/src/argrelay/custom_integ/ServiceLoader.py
@@ -134,6 +134,8 @@ class ServiceLoader(AbstractLoader):
 
         self.generate_envelope_id(data_envelopes)
 
+        self.generate_help_hints(data_envelopes)
+
         static_data.data_envelopes.extend(data_envelopes)
 
         return static_data
@@ -141,7 +143,7 @@ class ServiceLoader(AbstractLoader):
     # noinspection PyMethodMayBeStatic
     def generate_envelope_id(
         self,
-        data_envelopes: list,
+        data_envelopes: list[dict],
     ):
         for data_envelope in data_envelopes:
             if envelope_id_ not in data_envelope:
@@ -159,6 +161,30 @@ class ServiceLoader(AbstractLoader):
                         + "." +
                         data_envelope[ServiceArgType.ServiceName.name]
                     )
+
+    @staticmethod
+    def generate_help_hints(
+        data_envelopes: list[dict],
+    ):
+        """
+        Function demos FS_71_87_33_52 help_hint for `ServiceArgType.IpAddress`.
+
+        It simply generates `data_envelope`-s of `ReservedEnvelopeClass.ClassHelp` for
+        values of `ServiceArgType.IpAddress` equal to corresponding `ServiceArgType.HostName`.
+        """
+        help_hint_envelopes = []
+        for data_envelope in data_envelopes:
+            if data_envelope[ReservedArgType.EnvelopeClass.name] == ServiceEnvelopeClass.ClassHost.name:
+                if ServiceArgType.IpAddress.name in data_envelope:
+                    help_hint_envelopes.append({
+                        f"{ReservedArgType.EnvelopeClass.name}": f"{ReservedEnvelopeClass.ClassHelp.name}",
+                        f"{ReservedArgType.ArgType.name}": f"{ServiceArgType.IpAddress.name}",
+                        f"{ReservedArgType.ArgValue.name}": f"{data_envelope[ServiceArgType.IpAddress.name]}",
+                        f"{ReservedArgType.HelpHint.name}": f"{data_envelope[ServiceArgType.HostName.name]}",
+                    })
+
+        data_envelopes.extend(help_hint_envelopes)
+
 
     @staticmethod
     def populate_common_functions(

--- a/src/argrelay/enum_desc/ReservedArgType.py
+++ b/src/argrelay/enum_desc/ReservedArgType.py
@@ -3,4 +3,6 @@ from enum import Enum, auto
 
 class ReservedArgType(Enum):
     EnvelopeClass = auto()
+    ArgType = auto()
+    ArgValue = auto()
     HelpHint = auto()

--- a/src/argrelay/enum_desc/ReservedEnvelopeClass.py
+++ b/src/argrelay/enum_desc/ReservedEnvelopeClass.py
@@ -3,6 +3,7 @@ from enum import Enum, auto
 
 class ReservedEnvelopeClass(Enum):
     ClassFunction = auto()
+    ClassHelp = auto()
 
     def __str__(self):
         return self.name

--- a/src/argrelay/handler_request/AbstractServerRequestHandler.py
+++ b/src/argrelay/handler_request/AbstractServerRequestHandler.py
@@ -37,6 +37,7 @@ class AbstractServerRequestHandler:
             interp_factories = local_server.server_config.interp_factories,
             action_invocators = local_server.server_config.action_invocators,
             query_engine = local_server.get_query_engine(),
+            help_hint_cache = local_server.help_hint_cache,
         )
         self.interp_ctx.interpret_command(local_server.server_config.static_data.first_interp_factory_id)
         self.interp_ctx.print_debug()

--- a/src/argrelay/plugin_interp/FuncArgsInterp.py
+++ b/src/argrelay/plugin_interp/FuncArgsInterp.py
@@ -253,7 +253,9 @@ class FuncArgsInterp(AbstractInterp):
                 arg_type in self.interp_ctx.curr_container.remaining_types_to_values
             ):
                 proposed_values = [
-                    x for x in self.interp_ctx.curr_container.remaining_types_to_values[arg_type]
+                    # FS_71_87_33_52: `help_hint`:
+                    self.interp_ctx.help_hint_cache.get_value_with_help_hint(arg_type, x)
+                    for x in self.interp_ctx.curr_container.remaining_types_to_values[arg_type]
                     if (
                         isinstance(x, str)
                         and

--- a/src/argrelay/relay_server/HelpHintCache.py
+++ b/src/argrelay/relay_server/HelpHintCache.py
@@ -1,0 +1,45 @@
+from argrelay.enum_desc.ReservedArgType import ReservedArgType
+from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.misc_helper import eprint
+from argrelay.relay_server.QueryEngine import QueryEngine
+
+
+class HelpHintCache:
+    """
+    Implements FS_94_30_49_28 help hint.
+    """
+
+    def __init__(
+        self,
+        query_engine: QueryEngine,
+    ):
+        self.query_engine = query_engine
+        self.help_hint_dict = {}
+
+    def populate_cache(self):
+
+        help_hint_envelopes = self.query_engine.query_data_envelopes({
+            f"{ReservedArgType.EnvelopeClass.name}": f"{ReservedEnvelopeClass.ClassHelp.name}",
+        })
+
+        for help_hint_envelope in help_hint_envelopes:
+            arg_type = help_hint_envelope[ReservedArgType.ArgType.name]
+            arg_value = help_hint_envelope[ReservedArgType.ArgValue.name]
+            help_hint = help_hint_envelope[ReservedArgType.HelpHint.name]
+            if arg_type not in self.help_hint_dict:
+                self.help_hint_dict[arg_type] = {}
+            self.help_hint_dict[arg_type][arg_value] = help_hint
+
+        # TODO: clean up: debug only:
+        eprint(f"help_hint_dict: {self.help_hint_dict}")
+
+    def get_value_with_help_hint(
+        self,
+        arg_type: str,
+        arg_value: str,
+    ) -> str:
+        if arg_type in self.help_hint_dict:
+            if arg_value in self.help_hint_dict[arg_type]:
+                return f"{arg_value} # {self.help_hint_dict[arg_type][arg_value]}"
+        return arg_value
+

--- a/src/argrelay/relay_server/LocalServer.py
+++ b/src/argrelay/relay_server/LocalServer.py
@@ -9,6 +9,7 @@ from argrelay.mongo_data.MongoServerWrapper import MongoServerWrapper
 from argrelay.plugin_interp.AbstractInterpFactory import AbstractInterpFactory
 from argrelay.plugin_invocator.AbstractInvocator import AbstractInvocator
 from argrelay.plugin_loader.AbstractLoader import AbstractLoader
+from argrelay.relay_server.HelpHintCache import HelpHintCache
 from argrelay.relay_server.QueryEngine import QueryEngine
 from argrelay.runtime_data.ServerConfig import ServerConfig
 from argrelay.schema_config_core_server.StaticDataSchema import static_data_desc
@@ -25,6 +26,7 @@ class LocalServer:
     mongo_server: MongoServerWrapper
     mongo_client: MongoClient
     query_engine: QueryEngine
+    help_hint_cache: HelpHintCache
 
     def __init__(self, server_config: ServerConfig):
         self.server_config = server_config
@@ -34,12 +36,16 @@ class LocalServer:
             self.server_config.query_cache_config,
             self.get_mongo_database(),
         )
+        self.help_hint_cache = HelpHintCache(
+            self.query_engine,
+        )
 
     def start_local_server(self):
         self._activate_plugins()
         self._start_mongo_server()
         self._load_mongo_data()
         self._create_mongo_index()
+        self._populate_help_hint_cache()
 
     def get_mongo_database(self):
         return self.mongo_client[self.server_config.mongo_config.mongo_server.database_name]
@@ -126,3 +132,6 @@ class LocalServer:
             mongo_db,
             self.server_config.static_data,
         )
+
+    def _populate_help_hint_cache(self):
+        self.help_hint_cache.populate_cache()

--- a/src/argrelay/relay_server/path_config.py
+++ b/src/argrelay/relay_server/path_config.py
@@ -6,6 +6,7 @@ from argrelay.handler_request.AbstractServerRequestHandler import AbstractServer
 from argrelay.handler_request.DescribeLineArgsServerRequestHandler import DescribeLineArgsServerRequestHandler
 from argrelay.handler_request.ProposeArgValuesServerRequestHandler import ProposeArgValuesServerRequestHandler
 from argrelay.handler_request.RelayLineArgsServerRequestHandler import RelayLineArgsServerRequestHandler
+from argrelay.misc_helper import eprint
 from argrelay.misc_helper.ElapsedTime import ElapsedTime
 from argrelay.relay_server.LocalServer import LocalServer
 from argrelay.schema_request.RequestContextSchema import request_context_desc
@@ -65,6 +66,8 @@ def create_blueprint(local_server: LocalServer):
         send_plain_text = True
         try:
             if send_plain_text:
+                # TODO: clean up: debug only:
+                eprint(f"response_dict[arg_values_]: {response_dict[arg_values_]}")
                 return "\n".join(response_dict[arg_values_])
             else:
                 response_json = arg_values_desc.dict_schema.dumps(response_dict)

--- a/src/argrelay/runtime_context/EnvelopeContainer.py
+++ b/src/argrelay/runtime_context/EnvelopeContainer.py
@@ -72,7 +72,7 @@ class EnvelopeContainer:
         # TODO: print colorized command line (reordered by `search_control`) with consumed tokens, unconsumed tokens, tangent token
         is_first_missing_found: bool = False
         for envelope_container in envelope_containers:
-            eprint(f"{envelope_container.search_control.envelope_class}:")
+            eprint(f"{envelope_container.search_control.envelope_class}: {envelope_container.found_count}")
 
             for key_to_type_dict in envelope_container.search_control.keys_to_types_list:
                 arg_key = next(iter(key_to_type_dict))

--- a/src/argrelay/runtime_context/InterpContext.py
+++ b/src/argrelay/runtime_context/InterpContext.py
@@ -8,6 +8,7 @@ from argrelay.enum_desc.RunMode import RunMode
 from argrelay.enum_desc.TermColor import TermColor
 from argrelay.misc_helper import eprint
 from argrelay.misc_helper.ElapsedTime import ElapsedTime
+from argrelay.relay_server.HelpHintCache import HelpHintCache
 from argrelay.relay_server.QueryEngine import QueryEngine, populate_query_dict
 from argrelay.relay_server.QueryResult import QueryResult
 from argrelay.runtime_context.EnvelopeContainer import EnvelopeContainer
@@ -37,6 +38,8 @@ class InterpContext:
     """
 
     query_engine: QueryEngine
+
+    help_hint_cache: HelpHintCache
 
     unconsumed_tokens: list[int] = field(init = False)
     """
@@ -75,7 +78,7 @@ class InterpContext:
     Current interpreter during command line interpretation.
     """
 
-    comp_suggestions: list = field(init = False, default_factory = lambda: [])
+    comp_suggestions: list[str] = field(init = False, default_factory = lambda: [])
 
     def __post_init__(self):
         self.unconsumed_tokens = self._init_unconsumed_tokens()
@@ -215,6 +218,13 @@ class InterpContext:
             self.curr_interp.propose_arg_completion()
 
     def propose_arg_values(self) -> list[str]:
+        """
+        FS_71_87_33_52: remove `help_hint` (after first space) if there is only one option
+        """
+        if len(self.comp_suggestions) == 1:
+            first_space = self.comp_suggestions[0].find(' ')
+            if first_space >= 0:
+                self.comp_suggestions[0] = self.comp_suggestions[0][:first_space]
         return self.comp_suggestions
 
     def create_next_interp(

--- a/tests/offline_tests/relay_demo/test_relay_demo.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo.py
@@ -93,7 +93,7 @@ class ThisTestCase(InOutTestCase):
             actual_suggestions = "\n".join(command_obj.response_dict[arg_values_])
             self.assertEqual(expected_suggestions, actual_suggestions)
 
-    def test_propose_auto_comp_TD_63_37_05_36_default(self):
+    def test_propose_auto_comp_TD_63_37_05_36_demo(self):
         """
         Test arg values suggestion with TD_63_37_05_36 # demo
         """
@@ -191,6 +191,12 @@ class ThisTestCase(InOutTestCase):
                 line_no(), "some_command goto service q| whatever", CompType.PrefixHidden,
                 "qa",
                 "Unrecognized value does not obstruct suggestion",
+            ),
+            (
+                line_no(), "some_command goto host ip.192.168.1|", CompType.PrefixHidden,
+                "ip.192.168.1.1 # zxcv-du\nip.192.168.1.3 # poiu-dd",
+                "FS_71_87_33_52: If there are more than one suggestion and help_hint exists, "
+                "options are returned with hints",
             ),
         ]
         # @formatter:on
@@ -455,11 +461,11 @@ class ThisTestCase(InOutTestCase):
                 "FS_23_62_89_43: tangent token is taken into account in describe.",
                 f"""
 {TermColor.BRIGHT_BLUE.value}some_command{TermColor.RESET.value} {TermColor.BRIGHT_BLUE.value}goto{TermColor.RESET.value} {TermColor.BRIGHT_BLUE.value}service{TermColor.RESET.value} {TermColor.BRIGHT_BLUE.value}dev{TermColor.RESET.value} {TermColor.BRIGHT_BLUE.value}emea{TermColor.RESET.value} {TermColor.BRIGHT_BLUE.value}upstream{TermColor.RESET.value} {TermColor.DARK_MAGENTA.value}s_{TermColor.RESET.value} 
-{ReservedEnvelopeClass.ClassFunction.name}:
+{ReservedEnvelopeClass.ClassFunction.name}: 1
 {" " * indent_size}{TermColor.DARK_GREEN.value}FunctionCategory: external [{ArgSource.InitValue.name}]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.BRIGHT_BLUE.value}ActionType: goto [{ArgSource.ExplicitPosArg.name}]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.BRIGHT_BLUE.value}ObjectSelector: service [{ArgSource.ExplicitPosArg.name}]{TermColor.RESET.value}
-{ServiceEnvelopeClass.ClassService.name}:
+{ServiceEnvelopeClass.ClassService.name}: 2
 {" " * indent_size}{TermColor.BRIGHT_BLUE.value}CodeMaturity: dev [{ArgSource.ExplicitPosArg.name}]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.BRIGHT_BLUE.value}FlowStage: upstream [{ArgSource.ExplicitPosArg.name}]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.BRIGHT_BLUE.value}GeoRegion: emea [{ArgSource.ExplicitPosArg.name}]{TermColor.RESET.value}
@@ -469,7 +475,7 @@ class ThisTestCase(InOutTestCase):
 {" " * indent_size}{TermColor.BRIGHT_BLACK.value}LiveStatus: [none]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.DARK_GREEN.value}DataCenter: dc.22 [{ArgSource.ImplicitValue.name}]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.DARK_GREEN.value}IpAddress: ip.172.16.2.1 [{ArgSource.ImplicitValue.name}]{TermColor.RESET.value}
-{ServiceArgType.AccessType.name}:
+{ServiceArgType.AccessType.name}: 0
 {" " * indent_size}{TermColor.BRIGHT_BLACK.value}AccessType: [none]{TermColor.RESET.value}
 """,
             ),
@@ -479,18 +485,18 @@ class ThisTestCase(InOutTestCase):
                 # TODO: show differently `[none]` values: those in envelopes which haven't been searched yet, and those which were searched, but no values found in data.
                 f"""
 {TermColor.BRIGHT_BLUE.value}some_command{TermColor.RESET.value} {TermColor.BRIGHT_BLUE.value}goto{TermColor.RESET.value} {TermColor.BRIGHT_BLUE.value}host{TermColor.RESET.value} {TermColor.BRIGHT_BLUE.value}upstream{TermColor.RESET.value} 
-{ReservedEnvelopeClass.ClassFunction.name}:
+{ReservedEnvelopeClass.ClassFunction.name}: 1
 {" " * indent_size}{TermColor.DARK_GREEN.value}FunctionCategory: external [{ArgSource.InitValue.name}]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.BRIGHT_BLUE.value}ActionType: goto [{ArgSource.ExplicitPosArg.name}]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.BRIGHT_BLUE.value}ObjectSelector: host [{ArgSource.ExplicitPosArg.name}]{TermColor.RESET.value}
-{ServiceEnvelopeClass.ClassHost.name}:
+{ServiceEnvelopeClass.ClassHost.name}: 9
 {" " * indent_size}{TermColor.BRIGHT_YELLOW.value}*CodeMaturity: ?{TermColor.RESET.value} dev qa prod
 {" " * indent_size}{TermColor.BRIGHT_BLUE.value}FlowStage: upstream [{ArgSource.ExplicitPosArg.name}]{TermColor.RESET.value}
 {" " * indent_size}{TermColor.BRIGHT_YELLOW.value}GeoRegion: ?{TermColor.RESET.value} apac emea amer
 {" " * indent_size}{TermColor.BRIGHT_YELLOW.value}ClusterName: ?{TermColor.RESET.value} dev-apac-upstream dev-emea-upstream dev-amer-upstream qa-apac-upstream qa-amer-upstream prod-apac-upstream
 {" " * indent_size}{TermColor.BRIGHT_YELLOW.value}HostName: ?{TermColor.RESET.value} zxcv-du asdf-du qwer-du hjkl-qu poiu-qu rtyu-qu rt-qu qwer-pd-1 qwer-pd-2
 {" " * indent_size}{TermColor.BRIGHT_YELLOW.value}IpAddress: ?{TermColor.RESET.value} ip.192.168.1.1 ip.172.16.2.1 ip.192.168.3.1 ip.192.168.4.1 ip.172.16.4.2 ip.192.168.6.1 ip.192.168.6.2 ip.192.168.7.1 ip.172.16.7.2
-{ServiceArgType.AccessType.name}:
+{ServiceArgType.AccessType.name}: 0
 {" " * indent_size}{TermColor.BRIGHT_BLACK.value}AccessType: [none]{TermColor.RESET.value}
 """,
             ),


### PR DESCRIPTION
*   Show `help_hint` for `ServiceArgType.IpAddress` as initial POC.
*   All `help_hint`-s are loaded once and cached until server restarts (they may become stale).
*   Display `found_count` in describe output.
